### PR TITLE
Revert "remove feature flag which is now stabilized"

### DIFF
--- a/detcore/src/lib.rs
+++ b/detcore/src/lib.rs
@@ -8,14 +8,11 @@
 
 //! Detcore is a Reverie tool that determinizes the execution of a process.
 
-#![feature(cfg_version)]
 #![feature(async_closure)]
+#![feature(map_first_last)]
 #![feature(nonzero_ops)]
 #![deny(clippy::all)]
 #![deny(missing_docs)]
-#![cfg(not(version("1.66")))]
-#![feature(map_first_last)]
-
 mod config;
 mod consts;
 mod cpuid;


### PR DESCRIPTION
This reverts commit 66a93ab4e28235a9d82b737ed07c9098fce37571.

It was causing a build failure as reported by @rnbguy in #11.