### PR TITLE
[hermit][open-source] Add an extremely basic test script

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,3 +20,5 @@ jobs:
       run: sudo apt-get install -y libunwind-dev
     - name: Build
       run: cargo build
+    - name: Run basic tests.
+      run: ./scripts/basic_oss_tests.sh

--- a/scripts/basic_oss_tests.sh
+++ b/scripts/basic_oss_tests.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# The full hermit testing setup is Buck-based, and is not working in the OSS release yet.
+# This extremely basic test harness is a stop-gap.
+
+set -eEuo pipefail
+
+rootdir="$(pwd)"
+hermit="$rootdir/target/debug/hermit"
+hverify="$rootdir/target/debug/hermit-verify"
+
+function hermit_verify {
+    "$hverify" --hermit-bin="$hermit" run --isolate-workdir \
+               --hermit-arg="--base-env=empty" --hermit-arg="--env=HERMIT_MODE=strict" --hermit-arg="--preemption-timeout=80000000" \
+               "$1"
+}
+
+for script in "$rootdir"/tests/shell/*.sh; do
+    echo; echo "Running shell test: $script"
+#    hermit_verify "$script"
+done
+
+for bin in $(ls "$rootdir"/target/debug/rustbin_* | grep -v '\.d'); do
+    echo; echo "Running rust test: $bin"
+    hermit_verify "$bin"
+done


### PR DESCRIPTION
Summary:
While we wait to port our full buck testing setup to the OSS build, it's best to get at least a few integration tests running.

This diff uses a bash script for the purpose, though the next step would be to replace it with Rust code, possibly using libtest directly.

Test Plan:

Reviewers:

Subscribers:

Tasks:

Tags: