### PR TITLE
[hermit][open-source] enable basic cargo test unit tests under github…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,3 +20,5 @@ jobs:
       run: sudo apt-get install -y libunwind-dev
     - name: Build
       run: cargo build
+    - name: Unit tests
+      run: cargo test


### PR DESCRIPTION
… actions

Summary:
Github actions run under a VM that won't let us do most of our testing. But we can still do the very basics there as we work towards setting something else up for external (outside-Meta) CI.
