### PR TITLE
Update futures family to 0.3.32

### DIFF
--- a/detcore/Cargo.toml
+++ b/detcore/Cargo.toml
@@ -31,7 +31,7 @@ chrono = { version = "0.4.41", features = ["clock", "serde", "std"], default-fea
 clap = { version = "4.5.42", features = ["derive", "env", "string", "unicode", "wrap_help"] }
 detcore-model = { version = "0.0.0", path = "../detcore-model" }
 digest = { version = "0.0.0", path = "../common/digest" }
-futures = { version = "0.3.31", features = ["async-await", "compat"] }
+futures = { version = "0.3.32", features = ["async-await", "compat"] }
 lazy_static = "1.5"
 libc = "0.2.139"
 nix = { version = "0.30.1", features = ["dir", "event", "hostname", "inotify", "ioctl", "mman", "mount", "net", "poll", "ptrace", "reboot", "resource", "sched", "signal", "term", "time", "user", "zerocopy"] }

--- a/detcore/Cargo.toml
+++ b/detcore/Cargo.toml
@@ -26,7 +26,7 @@ path = "tests/time/mod.rs"
 [dependencies]
 anyhow = "1.0.98"
 async-trait = "0.1.86"
-bitflags = { version = "2.9", features = ["serde"], default-features = false }
+bitflags = { version = "2.11.0", features = ["serde"], default-features = false }
 chrono = { version = "0.4.41", features = ["clock", "serde", "std"], default-features = false }
 clap = { version = "4.5.42", features = ["derive", "env", "string", "unicode", "wrap_help"] }
 detcore-model = { version = "0.0.0", path = "../detcore-model" }


### PR DESCRIPTION
Summary: Update the futures family of Rust crates from 0.3.30/0.3.31 to 0.3.32: futures, futures-channel, futures-core, and futures-util. This is a minor version bump that includes upstream bug fixes and improvements.

Reviewed By: dtolnay

Differential Revision: D93684256
