### PR TITLE
Update uuid 1.17 to 1.21.0

### DIFF
--- a/detcore/Cargo.toml
+++ b/detcore/Cargo.toml
@@ -31,7 +31,7 @@ chrono = { version = "0.4.41", features = ["clock", "serde", "std"], default-fea
 clap = { version = "4.5.42", features = ["derive", "env", "string", "unicode", "wrap_help"] }
 detcore-model = { version = "0.0.0", path = "../detcore-model" }
 digest = { version = "0.0.0", path = "../common/digest" }
-futures = { version = "0.3.31", features = ["async-await", "compat"] }
+futures = { version = "0.3.32", features = ["async-await", "compat"] }
 lazy_static = "1.5"
 libc = "0.2.139"
 nix = { version = "0.30.1", features = ["dir", "event", "hostname", "inotify", "ioctl", "mman", "mount", "net", "poll", "ptrace", "reboot", "resource", "sched", "signal", "term", "time", "user", "zerocopy"] }

--- a/detcore/Cargo.toml
+++ b/detcore/Cargo.toml
@@ -26,7 +26,7 @@ path = "tests/time/mod.rs"
 [dependencies]
 anyhow = "1.0.98"
 async-trait = "0.1.86"
-bitflags = { version = "2.9", features = ["serde"], default-features = false }
+bitflags = { version = "2.11.0", features = ["serde"], default-features = false }
 chrono = { version = "0.4.41", features = ["clock", "serde", "std"], default-features = false }
 clap = { version = "4.5.42", features = ["derive", "env", "string", "unicode", "wrap_help"] }
 detcore-model = { version = "0.0.0", path = "../detcore-model" }

--- a/hermit-cli/Cargo.toml
+++ b/hermit-cli/Cargo.toml
@@ -37,4 +37,4 @@ tokio = { version = "1.47.1", features = ["full", "test-util", "tracing"] }
 tracing = { version = "0.1.41", features = ["attributes", "valuable"] }
 tracing-appender = "0.2.4"
 tracing-subscriber = { version = "0.3.20", features = ["chrono", "env-filter", "json", "local-time", "parking_lot", "registry"] }
-uuid = { version = "1.17", features = ["rng-getrandom", "serde", "v4", "v5", "v6", "v7", "v8"] }
+uuid = { version = "1.21.0", features = ["rng-getrandom", "serde", "v4", "v5", "v6", "v7", "v8"] }


### PR DESCRIPTION
Summary:
X-link: https://github.com/meta-pytorch/monarch/pull/2689

Update the uuid Rust crate from version 1.17 to 1.21.0. This is a minor version bump that includes upstream bug fixes and improvements.

Reviewed By: dtolnay

Differential Revision: D93684254
