### PR TITLE
upgrading tokio to 1.52.1

### DIFF
--- a/detcore/Cargo.toml
+++ b/detcore/Cargo.toml
@@ -47,7 +47,7 @@ reverie = { version = "0.1.0", git = "https://github.com/facebookexperimental/re
 serde = { version = "1.0.219", features = ["derive", "rc"] }
 serde_json = { version = "1.0.140", features = ["alloc", "float_roundtrip", "raw_value", "unbounded_depth"] }
 tempfile = "3.27.0"
-tokio = { version = "1.50.0", features = ["full", "test-util", "tracing"] }
+tokio = { version = "1.52.1", features = ["full", "test-util", "tracing"] }
 tracing = { version = "0.1.41", features = ["attributes", "valuable"] }
 
 [dev-dependencies]

--- a/detcore/tests/testutils/Cargo.toml
+++ b/detcore/tests/testutils/Cargo.toml
@@ -14,6 +14,6 @@ pretty_assertions = { version = "1.4.1", features = ["alloc"], default-features 
 reverie = { version = "0.1.0", git = "https://github.com/facebookexperimental/reverie.git", branch = "main" }
 reverie-ptrace = { version = "0.1.0", git = "https://github.com/facebookexperimental/reverie.git", branch = "main" }
 test-allocator = { version = "0.0.0", path = "../../../common/test-allocator" }
-tokio = { version = "1.50.0", features = ["full", "test-util", "tracing"] }
+tokio = { version = "1.52.1", features = ["full", "test-util", "tracing"] }
 tracing = { version = "0.1.41", features = ["attributes", "valuable"] }
 tracing-subscriber = { version = "0.3.23", features = ["chrono", "env-filter", "json", "local-time", "parking_lot", "registry"] }

--- a/hermit-cli/Cargo.toml
+++ b/hermit-cli/Cargo.toml
@@ -33,7 +33,7 @@ serde = { version = "1.0.219", features = ["derive", "rc"] }
 serde_json = { version = "1.0.140", features = ["alloc", "float_roundtrip", "raw_value", "unbounded_depth"] }
 shell-words = "1.1.1"
 tempfile = "3.27.0"
-tokio = { version = "1.50.0", features = ["full", "test-util", "tracing"] }
+tokio = { version = "1.52.1", features = ["full", "test-util", "tracing"] }
 tracing = { version = "0.1.41", features = ["attributes", "valuable"] }
 tracing-appender = "0.2.4"
 tracing-subscriber = { version = "0.3.23", features = ["chrono", "env-filter", "json", "local-time", "parking_lot", "registry"] }


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookincubator/below/pull/8278

X-link: https://github.com/facebookexperimental/dapper/pull/1

X-link: https://github.com/meta-pytorch/monarch/pull/3495

Upgrading `tokio` from `1.50.0` to `1.52.1`.
- All downstream consumers checked with arc rust-check — 0 errors.

Reviewed By: dtolnay

Differential Revision: D101580193
