### PR TITLE
fix(detcore): don't panic on unknown cpuid leaf

### DIFF
--- a/detcore/src/lib.rs
+++ b/detcore/src/lib.rs
@@ -621,7 +621,18 @@ impl<T: RecordOrReplay> Tool for Detcore<T> {
                 )
                 .await;
             }
-            intercepted.cpuid(eax).unwrap()
+            intercepted.cpuid(eax).unwrap_or_else(|| {
+                warn!(
+                    "[dtid {}] cpuid leaf 0x{:x} not in deterministic table; returning zero result",
+                    dettid, eax
+                );
+                CpuIdResult {
+                    eax: 0,
+                    ebx: 0,
+                    ecx: 0,
+                    edx: 0,
+                }
+            })
         } else {
             cpuid!(eax, ecx)
         };


### PR DESCRIPTION
Closes #32.

`InterceptedCpuid::cpuid` returns `None` for leaves outside the deterministic table (`CPUIDS` and `EXTENDED_CPUIDS`). The `.unwrap()` in `handle_cpuid_event` turned a guest CPUID for an unknown leaf into a hermit panic that took the whole tracee down. Fall back to a zero-valued `CpuIdResult` and log a warning, that matches what real x86 returns for out-of-range leaves and keeps the deterministic guarantee intact.