### PR TITLE
Make run option tests independent of PMU support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,9 @@ jobs:
     - name: Build
       run: cargo build --workspace
     - name: Test regular workspace crates
-      run: cargo test --workspace --exclude detcore
+      run: cargo test --workspace --exclude detcore --exclude hermit
+    - name: Test Hermit without namespace-dependent integration tests
+      run: cargo test -p hermit --lib --bins
     - name: Test Detcore without hardware-dependent integration tests
       run: |
         cargo test -p detcore --lib --bins
@@ -37,7 +39,7 @@ jobs:
       run: cargo fmt --all -- --check
 
   hardware:
-    name: Hardware-dependent tests (self-hosted, disabled)
+    name: Host-dependent tests (self-hosted, disabled)
     if: ${{ false }} # Enable after a compatible runner is available.
     runs-on: [self-hosted, linux, x64]
 
@@ -49,3 +51,5 @@ jobs:
       run: cargo test -p detcore --test tests_misc
     - name: PMU preemption and CPU instruction tests
       run: cargo test -p detcore --test tests_parallelism --test tests_time
+    - name: Hermit user namespace integration tests
+      run: cargo test -p hermit --test hermit_modes

--- a/hermit-cli/src/bin/hermit/run.rs
+++ b/hermit-cli/src/bin/hermit/run.rs
@@ -459,7 +459,7 @@ impl fmt::Display for RunOpts {
 fn display_runopts1() {
     let vec: Vec<&str> = vec!["fakehermit", "fakeprog", "arg1", "arg2"];
     let mut ro = RunOpts::parse_from(vec.iter());
-    ro.validate_args();
+    ro.validate_args_with_perf_support(true);
     assert_eq!(format!("{}", ro), " -- fakeprog arg1 arg2");
 }
 
@@ -473,7 +473,7 @@ fn display_runopts2() {
         "arg2",
     ];
     let mut ro = RunOpts::parse_from(vec.iter());
-    ro.validate_args();
+    ro.validate_args_with_perf_support(true);
     assert_eq!(format!("{}", ro), " -- fakeprog arg1 arg2");
 }
 
@@ -489,7 +489,7 @@ fn display_runopts3() {
         "arg2",
     ];
     let mut ro = RunOpts::parse_from(vec.iter());
-    ro.validate_args();
+    ro.validate_args_with_perf_support(true);
     assert_eq!(
         format!("{}", ro),
         " --no-sequentialize-threads --no-virtualize-metadata --epoch=2000-12-31T23:59:59+00:00 -- fakeprog arg1 arg2"
@@ -500,8 +500,18 @@ fn display_runopts3() {
 fn display_runopts4() {
     let vec: Vec<&str> = vec!["fakehermit", "--sequentialize-threads", "fakeprog", "arg1"];
     let mut ro = RunOpts::parse_from(vec.iter());
-    ro.validate_args();
+    ro.validate_args_with_perf_support(true);
     assert_eq!(format!("{}", ro), " -- fakeprog arg1");
+}
+
+#[test]
+fn display_runopts_without_perf_support() {
+    let mut ro = RunOpts::parse_from(["fakehermit", "fakeprog", "arg1"]);
+    ro.validate_args_with_perf_support(false);
+    assert_eq!(
+        format!("{}", ro),
+        " --preemption-timeout=disabled -- fakeprog arg1"
+    );
 }
 
 /// Create two logging destinations and two global configs. Returns non-zero exit
@@ -529,6 +539,10 @@ impl RunOpts {
     /// Some arguments imply others. This is the place where that validation occurs.
     /// Also this performs side effects like accessing system randomness to implement --seed-from=SystemArgs
     pub fn validate_args(&mut self) {
+        self.validate_args_with_perf_support(reverie_ptrace::is_perf_supported());
+    }
+
+    fn validate_args_with_perf_support(&mut self, perf_supported: bool) {
         let config = &mut self.det_opts.det_config;
 
         config.has_uts_namespace = true;
@@ -553,7 +567,7 @@ impl RunOpts {
 
         // This is a Detcore Config-internal matter, but relies on reverie_ptrace, which detcore is
         // allowed to depend on:
-        if config.preemption_timeout.is_some() && !reverie_ptrace::is_perf_supported() {
+        if config.preemption_timeout.is_some() && !perf_supported {
             // TODO(T124429978): this could change back to tracing::warn! when the bug is fixed:
             eprintln!(
                 "WARNING: --preemption-timout requires hardware perf counters \

--- a/hermit-verify/src/common/env.rs
+++ b/hermit-verify/src/common/env.rs
@@ -239,7 +239,7 @@ mod test {
 
         let path = env.path.path().display().to_string();
 
-        let result: Vec<_> = env
+        let mut result: Vec<_> = env
             .runs()
             .iter()
             .map(|run| std::fs::read_dir(run.temp_dir.as_path()))
@@ -259,7 +259,8 @@ mod test {
             })
             .collect();
 
-        let expected = vec![
+        result.sort();
+        let mut expected = vec![
             "/1/workdir",
             "/1/log",
             "/1/std_out",
@@ -276,6 +277,7 @@ mod test {
         .into_iter()
         .map(str::to_owned)
         .collect::<Vec<_>>();
+        expected.sort();
 
         assert_eq!(result, expected);
 

--- a/hermit-verify/src/common/test_artifacts.rs
+++ b/hermit-verify/src/common/test_artifacts.rs
@@ -69,7 +69,7 @@ mod test {
         artifacts.copy_run_results(&env)?;
 
         let files = std::fs::read_dir(artifactd_dir.path())?;
-        let expected_artifacts = vec![
+        let mut expected_artifacts = vec![
             format!("{}/1_log", artifactd_dir.path().display()),
             format!("{}/1_std_out", artifactd_dir.path().display()),
             format!("{}/1_std_err", artifactd_dir.path().display()),
@@ -81,11 +81,13 @@ mod test {
             format!("{}/2_exit_status", artifactd_dir.path().display()),
             format!("{}/2_sched", artifactd_dir.path().display()),
         ];
+        expected_artifacts.sort();
 
-        let copied_artifacts: Vec<String> = files
+        let mut copied_artifacts: Vec<String> = files
             .into_iter()
             .map(|p| format!("{}", p.unwrap().path().display()))
             .collect();
+        copied_artifacts.sort();
 
         assert_eq!(expected_artifacts, copied_artifacts);
         Ok(())


### PR DESCRIPTION
## Summary
- make run option formatter tests independent of host PMU availability
- keep Hermit unit and binary tests on GitHub-hosted runners
- route UID-map/user-namespace integrations to the disabled compatible self-hosted job
- remove filesystem directory-order assumptions from Hermit Verify tests

## Context
Successive integration/PR runs exposed three host assumptions: unavailable PMU counters, unavailable UID-mapped user namespaces, and unspecified `read_dir()` ordering. This PR preserves portable hosted coverage and tracks privileged targets in the compatible-runner job.

## Verification
- `cargo test -p hermit --bin hermit run::display_runopts`
- `cargo test -p hermit-verify`
- `cargo test --workspace --exclude detcore --exclude hermit`
- `cargo test -p hermit --lib --bins`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo fmt --all -- --check`