### PR TITLE
Port remaining Detcore tests to Cargo

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Dependencies
-      run: sudo apt-get install -y libunwind-dev liblzma-dev
+      run: sudo apt-get install -y golang-go libunwind-dev liblzma-dev
     - name: Build
       run: cargo build --workspace
     - name: Test regular workspace crates
@@ -44,8 +44,10 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Dependencies
-      run: sudo apt-get install -y libunwind-dev liblzma-dev
+      run: sudo apt-get install -y golang-go libunwind-dev liblzma-dev
     - name: CPUID and RDRAND/RDSEED tests
       run: cargo test -p detcore --test tests_misc
     - name: PMU preemption and CPU instruction tests
-      run: cargo test -p detcore --test tests_parallelism --test tests_time
+      run: |
+        cargo test -p detcore --test tests_parallelism --test tests_time -- --ignored --test-threads=1
+        cargo test -p hermit --test detcore_lit -- --ignored --test-threads=1

--- a/detcore/tests/lit/README.md
+++ b/detcore/tests/lit/README.md
@@ -4,12 +4,14 @@ This directory contains integration tests where a specific (or patterned)
 stdout is expected. This is good for testing that a program's output is
 deterministic.
 
-These tests are run through LLVM's [`lit`][] tool. Please reference the
-[`FileCheck`][] documentation to understand the directives that can be used
-for checking on the output of tests.
+Buck runs these tests through LLVM's [`lit`][] tool. Cargo uses the compatible
+runner in `cargo.rs` and the Rust [`litcheck-filecheck`][] implementation.
+Please reference the [`FileCheck`][] documentation to understand the
+directives that can be used for checking test output.
 
 [`lit`]: https://llvm.org/docs/CommandGuide/lit.html
 [`FileCheck`]: https://llvm.org/docs/CommandGuide/FileCheck.html
+[`litcheck-filecheck`]: https://crates.io/crates/litcheck-filecheck
 
 ## Test discovery
 
@@ -24,5 +26,16 @@ easily generate a new lit test:
 This will generate a test called `foobar` with a `main.rs`.
 
 ## Running the tests
+
+Cargo runs the hardware-independent tests by default. PMU-dependent strict,
+chaos, and verify cases are ignored unless explicitly requested:
+
+    cargo test -p hermit --test detcore_lit
+    cargo test -p hermit --test detcore_lit -- --ignored --test-threads=1
+
+Each Cargo test gets its own working directory and `TMPDIR`, so tests that
+bind or preserve `/tmp` do not share state.
+
+Buck continues to use LLVM lit directly:
 
     buck test //hermetic_infra/detcore/tests/lit/...

--- a/detcore/tests/lit/cargo.rs
+++ b/detcore/tests/lit/cargo.rs
@@ -1,0 +1,621 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+//! Cargo runner for the Detcore LLVM lit tests.
+
+use std::fs;
+use std::io::Write;
+use std::path::Path;
+use std::path::PathBuf;
+use std::process::Command;
+use std::process::Output;
+use std::sync::Mutex;
+use std::sync::MutexGuard;
+use std::sync::OnceLock;
+
+use litcheck_filecheck::Config;
+use litcheck_filecheck::Test;
+use litcheck_filecheck::litcheck::Symbol;
+
+static LIT_LOCK: Mutex<()> = Mutex::new(());
+static NATIVE_FIXTURES: OnceLock<NativeFixtures> = OnceLock::new();
+
+struct NativeFixtures {
+    hello_world_c: PathBuf,
+    hello_world_go: PathBuf,
+    networking: PathBuf,
+    rt_sigaction: PathBuf,
+    rt_sigprocmask: PathBuf,
+}
+
+fn lit_lock() -> MutexGuard<'static, ()> {
+    LIT_LOCK
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+}
+
+fn repository() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .expect("hermit-cli must be inside the repository")
+        .to_path_buf()
+}
+
+fn lit_root() -> PathBuf {
+    repository().join("detcore/tests/lit")
+}
+
+fn command_output(mut command: Command, label: &str) -> Output {
+    let rendered = format!("{command:?}");
+    let output = command
+        .output()
+        .unwrap_or_else(|error| panic!("failed to start {label}: {rendered}: {error}"));
+    assert!(
+        output.status.success(),
+        "{label} failed: {rendered}\nstatus: {}\nstdout:\n{}\nstderr:\n{}",
+        output.status,
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+    output
+}
+
+fn compile_c(source: &Path, output: &Path) {
+    let mut command = Command::new("cc");
+    command
+        .args([
+            "-D_POSIX_C_SOURCE=20180920",
+            "-D_GNU_SOURCE=1",
+            "-UNDEBUG",
+            "-pthread",
+        ])
+        .arg(source)
+        .arg("-o")
+        .arg(output);
+    command_output(command, "C lit fixture compilation");
+}
+
+fn compile_go(source: &Path, output: &Path) {
+    let mut command = Command::new("go");
+    command.arg("build").arg("-o").arg(output).arg(source);
+    command_output(command, "Go lit fixture compilation");
+}
+
+fn native_fixtures() -> &'static NativeFixtures {
+    NATIVE_FIXTURES.get_or_init(|| {
+        let root = lit_root();
+        let output = Path::new(env!("CARGO_TARGET_TMPDIR")).join("detcore-lit-fixtures");
+        fs::create_dir_all(&output).expect("failed to create native fixture directory");
+
+        let hello_world_c = output.join("hello_world_c");
+        let networking = output.join("networking");
+        let rt_sigaction = output.join("rt_sigaction");
+        let rt_sigprocmask = output.join("rt_sigprocmask");
+        let hello_world_go = output.join("hello_world_go");
+
+        compile_c(&root.join("hello_world_c/main.c"), &hello_world_c);
+        compile_c(&root.join("networking/main.c"), &networking);
+        compile_c(&root.join("rt_sigaction/main.c"), &rt_sigaction);
+        compile_c(&root.join("rt_sigprocmask/main.c"), &rt_sigprocmask);
+        compile_go(&root.join("hello_world_go/main.go"), &hello_world_go);
+
+        NativeFixtures {
+            hello_world_c,
+            hello_world_go,
+            networking,
+            rt_sigaction,
+            rt_sigprocmask,
+        }
+    })
+}
+
+fn fixture_path(name: &str) -> PathBuf {
+    let native = native_fixtures();
+    match name {
+        "hello_world_c" => native.hello_world_c.clone(),
+        "hello_world_go" => native.hello_world_go.clone(),
+        "networking" => native.networking.clone(),
+        "rt_sigaction" => native.rt_sigaction.clone(),
+        "rt_sigprocmask" => native.rt_sigprocmask.clone(),
+        _ => PathBuf::from(env!("CARGO_BIN_EXE_detcore-lit-fixture")),
+    }
+}
+
+fn shell_quote(path: &Path) -> String {
+    shell_words::quote(&path.to_string_lossy()).into_owned()
+}
+
+fn run_directive(directive: &str, source: &Path, fixture: Option<&str>, workdir: &Path) {
+    let hermit = shell_quote(Path::new(env!("CARGO_BIN_EXE_hermit")));
+    let uses_hermit = directive.contains("%hermit");
+    let source_is_script = source.extension().is_some_and(|ext| ext == "sh");
+    let fixture_path = fixture.map(fixture_path);
+    let local_fixture = fixture_path.as_ref().map(|fixture| {
+        let local = workdir.join("fixture");
+        fs::copy(fixture, &local).unwrap_or_else(|error| {
+            panic!(
+                "failed to copy lit fixture {} to {}: {error}",
+                fixture.display(),
+                local.display()
+            )
+        });
+        local
+    });
+    let fixture_arg = local_fixture.as_ref().map(|fixture| {
+        if uses_hermit {
+            "/tmp/fixture".to_owned()
+        } else {
+            shell_quote(fixture)
+        }
+    });
+    let local_script = if uses_hermit && source_is_script {
+        let local = workdir.join("test.sh");
+        fs::copy(source, &local).unwrap_or_else(|error| {
+            panic!(
+                "failed to copy lit source {} to {}: {error}",
+                source.display(),
+                local.display()
+            )
+        });
+        Some(local)
+    } else {
+        None
+    };
+    let source_arg = if local_script.is_some() {
+        "/tmp/test.sh".to_owned()
+    } else {
+        shell_quote(source)
+    };
+    let guest_payload = local_fixture
+        .as_ref()
+        .map(|path| (path, "/tmp/fixture"))
+        .or_else(|| local_script.as_ref().map(|path| (path, "/tmp/test.sh")));
+    let run_args = if let Some((source, target)) = guest_payload {
+        let mount = format!(
+            "type=bind,source={},target={target}",
+            source.to_string_lossy()
+        );
+        format!(
+            " run --mount={} --env=TMPDIR=/tmp ",
+            shell_words::quote(&mount)
+        )
+    } else {
+        " run ".to_owned()
+    };
+
+    let mut command = directive
+        .replace("%hermit", &hermit)
+        .replace("%me", fixture_arg.as_deref().unwrap_or("%me"))
+        .replace("%s", &source_arg);
+    command = command.replacen(" run ", &run_args, 1);
+    if source_is_script {
+        command = command.replace(" --bind /tmp", "");
+    }
+
+    let (command, filecheck) = if let Some((command, args)) = command.split_once(" |& FileCheck") {
+        (format!("{command} 2>&1"), Some(args))
+    } else if let Some((command, args)) = command.split_once(" | FileCheck") {
+        (command.to_owned(), Some(args))
+    } else {
+        (command, None)
+    };
+
+    let mut process = Command::new("bash");
+    process.args(["-c", &command]).current_dir(workdir).env(
+        "TMPDIR",
+        if uses_hermit {
+            Path::new("/tmp")
+        } else {
+            workdir
+        },
+    );
+    if let Some(fixture) = fixture {
+        process.env("HERMIT_LIT_FIXTURE", fixture);
+    }
+
+    let rendered = format!("{process:?}");
+    let output = process
+        .output()
+        .unwrap_or_else(|error| panic!("failed to run lit command {rendered}: {error}"));
+    assert!(
+        output.status.success(),
+        "lit command failed: {rendered}\nstatus: {}\nstdout:\n{}\nstderr:\n{}",
+        output.status,
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+
+    if let Some(filecheck_args) = filecheck {
+        let prefix = filecheck_args
+            .split_whitespace()
+            .find_map(|arg| arg.strip_prefix("--check-prefix="))
+            .unwrap_or("CHECK");
+        let mut config = Config::default();
+        config.options.check_prefixes = vec![Symbol::intern(prefix)];
+
+        let mut input =
+            tempfile::NamedTempFile::new_in(workdir).expect("failed to create FileCheck input");
+        input
+            .write_all(&output.stdout)
+            .expect("failed to write FileCheck input");
+
+        Test::from_file(source, &config)
+            .verify_file(input.path())
+            .unwrap_or_else(|error| {
+                panic!(
+                    "FileCheck failed for {rendered}: {error:?}\nstdout:\n{}\nstderr:\n{}",
+                    String::from_utf8_lossy(&output.stdout),
+                    String::from_utf8_lossy(&output.stderr),
+                )
+            });
+    }
+}
+
+fn run_lit(relative_path: &str, fixture: Option<&str>) {
+    let _guard = lit_lock();
+    let source = lit_root().join(relative_path);
+    let contents = fs::read_to_string(&source)
+        .unwrap_or_else(|error| panic!("failed to read {}: {error}", source.display()));
+    let workdir = tempfile::Builder::new()
+        .prefix("hermit-detcore-lit-")
+        .tempdir()
+        .expect("failed to create lit working directory");
+
+    let directives: Vec<_> = contents
+        .lines()
+        .filter_map(|line| line.find("RUN:").map(|index| line[index + 4..].trim()))
+        .collect();
+    assert!(
+        !directives.is_empty(),
+        "{} contains no RUN directives",
+        source.display()
+    );
+
+    for directive in directives {
+        run_directive(directive, &source, fixture, workdir.path());
+    }
+}
+
+macro_rules! lit_test {
+    ($name:ident, $path:literal, $fixture:expr) => {
+        #[test]
+        fn $name() {
+            run_lit($path, $fixture);
+        }
+    };
+}
+
+macro_rules! pmu_lit_test {
+    ($name:ident, $path:literal, $fixture:expr) => {
+        #[test]
+        #[ignore = "requires PMU support for RCB counting"]
+        fn $name() {
+            run_lit($path, $fixture);
+        }
+    };
+}
+
+lit_test!(
+    child_should_inherit_fds,
+    "child_should_inherit_fds/main.rs",
+    Some("child_should_inherit_fds")
+);
+lit_test!(
+    child_should_inherit_fds_hermit_run,
+    "child_should_inherit_fds/hermit-run.lit",
+    Some("child_should_inherit_fds")
+);
+lit_test!(
+    close_on_exec,
+    "close_on_exec/main.rs",
+    Some("close_on_exec")
+);
+lit_test!(
+    close_on_exec_hermit_run,
+    "close_on_exec/hermit-run.lit",
+    Some("close_on_exec")
+);
+lit_test!(
+    dup2_existing_fd,
+    "dup2_existing_fd/main.rs",
+    Some("dup2_existing_fd")
+);
+lit_test!(
+    dup2_existing_fd_hermit_run,
+    "dup2_existing_fd/hermit-run.lit",
+    Some("dup2_existing_fd")
+);
+lit_test!(
+    dup_should_create_a_valid_fd,
+    "dup_should_create_a_valid_fd/main.rs",
+    Some("dup_should_create_a_valid_fd")
+);
+lit_test!(
+    dup_should_create_a_valid_fd_hermit_run,
+    "dup_should_create_a_valid_fd/hermit-run.lit",
+    Some("dup_should_create_a_valid_fd")
+);
+lit_test!(fcntl_dupfd, "fcntl_dupfd/main.rs", Some("fcntl_dupfd"));
+lit_test!(
+    fcntl_dupfd_hermit_run,
+    "fcntl_dupfd/hermit-run.lit",
+    Some("fcntl_dupfd")
+);
+lit_test!(
+    fcntl_getfd_setfd,
+    "fcntl_getfd_setfd/main.rs",
+    Some("fcntl_getfd_setfd")
+);
+lit_test!(
+    fcntl_getfd_setfd_hermit_run,
+    "fcntl_getfd_setfd/hermit-run.lit",
+    Some("fcntl_getfd_setfd")
+);
+lit_test!(
+    file_race_openwrite,
+    "file_race_openwrite/main.rs",
+    Some("file_race_openwrite")
+);
+lit_test!(
+    file_race_openwrite_hermit_run,
+    "file_race_openwrite/hermit-run.lit",
+    Some("file_race_openwrite")
+);
+lit_test!(
+    file_write_race,
+    "file_write_race/main.rs",
+    Some("file_write_race")
+);
+lit_test!(
+    file_write_race_hermit_run,
+    "file_write_race/hermit-run.lit",
+    Some("file_write_race")
+);
+lit_test!(fstat, "fstat/main.rs", Some("fstat"));
+lit_test!(fstat_hermit_run, "fstat/hermit-run.lit", Some("fstat"));
+lit_test!(hello_world_c, "hello_world_c/main.c", Some("hello_world_c"));
+lit_test!(
+    hello_world_c_hermit_run,
+    "hello_world_c/hermit-run.lit",
+    Some("hello_world_c")
+);
+lit_test!(
+    hello_world_go,
+    "hello_world_go/main.go",
+    Some("hello_world_go")
+);
+lit_test!(
+    hello_world_go_hermit_run,
+    "hello_world_go/hermit-run.lit",
+    Some("hello_world_go")
+);
+lit_test!(
+    hello_world_rs_hermit_run,
+    "hello_world_rs/hermit-run.lit",
+    Some("hello_world_rs")
+);
+lit_test!(networking, "networking/main.c", Some("networking"));
+lit_test!(
+    networking_hermit_run,
+    "networking/hermit-run.lit",
+    Some("networking")
+);
+lit_test!(
+    no_close_on_exec,
+    "no_close_on_exec/main.rs",
+    Some("no_close_on_exec")
+);
+lit_test!(
+    no_close_on_exec_hermit_run,
+    "no_close_on_exec/hermit-run.lit",
+    Some("no_close_on_exec")
+);
+lit_test!(
+    open_null_ptr,
+    "open_null_ptr/main.rs",
+    Some("open_null_ptr")
+);
+lit_test!(
+    open_null_ptr_hermit_run,
+    "open_null_ptr/hermit-run.lit",
+    Some("open_null_ptr")
+);
+lit_test!(
+    openat_lowest_fd,
+    "openat_lowest_fd/main.rs",
+    Some("openat_lowest_fd")
+);
+lit_test!(
+    openat_lowest_fd_hermit_run,
+    "openat_lowest_fd/hermit-run.lit",
+    Some("openat_lowest_fd")
+);
+lit_test!(
+    openat_next_lowest_fd,
+    "openat_next_lowest_fd/main.rs",
+    Some("openat_next_lowest_fd")
+);
+lit_test!(
+    openat_next_lowest_fd_hermit_run,
+    "openat_next_lowest_fd/hermit-run.lit",
+    Some("openat_next_lowest_fd")
+);
+lit_test!(
+    pipe_creates_valid_fds,
+    "pipe_creates_valid_fds/main.rs",
+    Some("pipe_creates_valid_fds")
+);
+lit_test!(
+    pipe_creates_valid_fds_hermit_run,
+    "pipe_creates_valid_fds/hermit-run.lit",
+    Some("pipe_creates_valid_fds")
+);
+lit_test!(print_race, "print_race/main.rs", Some("print_race"));
+lit_test!(read_badfd, "read_badfd/main.rs", Some("read_badfd"));
+lit_test!(
+    read_badfd_hermit_run,
+    "read_badfd/hermit-run.lit",
+    Some("read_badfd")
+);
+lit_test!(rt_sigaction, "rt_sigaction/main.c", Some("rt_sigaction"));
+lit_test!(
+    rt_sigaction_hermit_run,
+    "rt_sigaction/hermit-run.lit",
+    Some("rt_sigaction")
+);
+lit_test!(
+    rt_sigprocmask,
+    "rt_sigprocmask/main.c",
+    Some("rt_sigprocmask")
+);
+lit_test!(
+    rt_sigprocmask_hermit_run,
+    "rt_sigprocmask/hermit-run.lit",
+    Some("rt_sigprocmask")
+);
+lit_test!(
+    sched_getaffinity,
+    "sched_getaffinity/main.rs",
+    Some("sched_getaffinity")
+);
+lit_test!(tmpfs, "tmpfs.test", None);
+lit_test!(tmpfs_preserved, "tmpfs_preserved.test", None);
+lit_test!(uname, "uname.test", None);
+lit_test!(utime, "utime/main.rs", Some("utime"));
+lit_test!(utime_hermit_run, "utime/hermit-run.lit", Some("utime"));
+lit_test!(utimes, "utimes/main.rs", Some("utimes"));
+lit_test!(utimes_hermit_run, "utimes/hermit-run.lit", Some("utimes"));
+lit_test!(exit_code, "exit_code.test", None);
+
+pmu_lit_test!(cat, "cat.test", None);
+pmu_lit_test!(
+    dup2_existing_fd_hermit_run_strict,
+    "dup2_existing_fd/hermit-run-strict.lit",
+    Some("dup2_existing_fd")
+);
+pmu_lit_test!(
+    dup_should_create_a_valid_fd_hermit_run_strict,
+    "dup_should_create_a_valid_fd/hermit-run-strict.lit",
+    Some("dup_should_create_a_valid_fd")
+);
+pmu_lit_test!(
+    fcntl_dupfd_hermit_run_strict,
+    "fcntl_dupfd/hermit-run-strict.lit",
+    Some("fcntl_dupfd")
+);
+pmu_lit_test!(
+    fcntl_getfd_setfd_hermit_run_strict,
+    "fcntl_getfd_setfd/hermit-run-strict.lit",
+    Some("fcntl_getfd_setfd")
+);
+pmu_lit_test!(
+    file_race_openwrite_hermit_run_strict,
+    "file_race_openwrite/hermit-run-strict.lit",
+    Some("file_race_openwrite")
+);
+pmu_lit_test!(
+    file_write_race_hermit_run_strict,
+    "file_write_race/hermit-run-strict.lit",
+    Some("file_write_race")
+);
+pmu_lit_test!(
+    fstat_hermit_run_strict,
+    "fstat/hermit-run-strict.lit",
+    Some("fstat")
+);
+pmu_lit_test!(
+    hello_world_c_hermit_run_strict,
+    "hello_world_c/hermit-run-strict.lit",
+    Some("hello_world_c")
+);
+pmu_lit_test!(
+    hello_world_go_hermit_run_strict,
+    "hello_world_go/hermit-run-strict.lit",
+    Some("hello_world_go")
+);
+pmu_lit_test!(
+    hello_world_go_hermit_run_strict_verify,
+    "hello_world_go/hermit-run-strict-verify.lit",
+    Some("hello_world_go")
+);
+pmu_lit_test!(
+    hello_world_rs,
+    "hello_world_rs/main.rs",
+    Some("hello_world_rs")
+);
+pmu_lit_test!(
+    hello_world_rs_hermit_run_strict,
+    "hello_world_rs/hermit-run-strict.lit",
+    Some("hello_world_rs")
+);
+pmu_lit_test!(hostname, "hostname.test", None);
+pmu_lit_test!(
+    open_null_ptr_hermit_run_strict,
+    "open_null_ptr/hermit-run-strict.lit",
+    Some("open_null_ptr")
+);
+pmu_lit_test!(
+    openat_lowest_fd_hermit_run_strict,
+    "openat_lowest_fd/hermit-run-strict.lit",
+    Some("openat_lowest_fd")
+);
+pmu_lit_test!(
+    openat_next_lowest_fd_hermit_run_strict,
+    "openat_next_lowest_fd/hermit-run-strict.lit",
+    Some("openat_next_lowest_fd")
+);
+pmu_lit_test!(
+    pipe_creates_valid_fds_hermit_run_strict,
+    "pipe_creates_valid_fds/hermit-run-strict.lit",
+    Some("pipe_creates_valid_fds")
+);
+pmu_lit_test!(
+    print_race_hermit_run_strict,
+    "print_race/hermit-run-strict.lit",
+    Some("print_race")
+);
+pmu_lit_test!(
+    print_race_hermit_run_strict_verify,
+    "print_race/hermit-run-strict-verify.lit",
+    Some("print_race")
+);
+pmu_lit_test!(
+    read_badfd_hermit_run_strict,
+    "read_badfd/hermit-run-strict.lit",
+    Some("read_badfd")
+);
+pmu_lit_test!(
+    sched_getaffinity_hermit_run_strict,
+    "sched_getaffinity/hermit-run-strict.lit",
+    Some("sched_getaffinity")
+);
+pmu_lit_test!(
+    sched_getaffinity_hermit_run_strict_verify,
+    "sched_getaffinity/hermit-run-strict-verify.lit",
+    Some("sched_getaffinity")
+);
+pmu_lit_test!(
+    scheduler_strategies_chaos_verify,
+    "scheduler_strategies/hermit-run-shedulers-chaos-verify.sh",
+    None
+);
+pmu_lit_test!(
+    scheduler_strategies_strict_verify,
+    "scheduler_strategies/hermit-run-shedulers-strict-verify.sh",
+    None
+);
+pmu_lit_test!(
+    utime_hermit_run_strict,
+    "utime/hermit-run-strict.lit",
+    Some("utime")
+);
+pmu_lit_test!(
+    utimes_hermit_run_strict,
+    "utimes/hermit-run-strict.lit",
+    Some("utimes")
+);

--- a/detcore/tests/lit/close_on_exec/main.rs
+++ b/detcore/tests/lit/close_on_exec/main.rs
@@ -6,8 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-//! Tests that a file descriptor is automatically closed after execve if
-//! O_CLOEXEC was specified. See also the `no_close_on_exec` test.
+// Tests that a file descriptor is automatically closed after execve if
+// O_CLOEXEC was specified. See also the `no_close_on_exec` test.
 
 // RUN: %me
 
@@ -67,14 +67,19 @@ fn main() {
         ForkResult::Child => {
             fdread.close().expect("close failed");
 
-            let proc_self = "/proc/self/exe\0".as_ptr() as *const libc::c_char;
+            let proc_self = c"/proc/self/exe".as_ptr();
 
             // Execute thyself, passing in the pipe's file descriptor.
             unsafe {
+                let fixture_env = b"HERMIT_LIT_FIXTURE=close_on_exec\0";
+                let env = [
+                    fixture_env.as_ptr() as *const libc::c_char,
+                    ptr::null(),
+                ];
                 libc::execve(
                     proc_self,
                     &[proc_self, fdwrite_str.as_ptr() as *const _, ptr::null()] as *const *const _,
-                    &[ptr::null()] as *const *const _,
+                    env.as_ptr(),
                 )
             };
 

--- a/detcore/tests/lit/file_write_race/main.rs
+++ b/detcore/tests/lit/file_write_race/main.rs
@@ -6,8 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-//! Threads racing to write the same file, dup'ing the file descriptor. Exercises
-//! SYS_fcntl with F_DUPFD_CLOEXEC.
+// Threads racing to write the same file, dup'ing the file descriptor. Exercises
+// SYS_fcntl with F_DUPFD_CLOEXEC.
 
 // RUN: %me | FileCheck %s
 // CHECK: {{([12]{20})}}

--- a/detcore/tests/lit/fixture.rs
+++ b/detcore/tests/lit/fixture.rs
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+//! Cargo entry point for Rust programs used by the Detcore lit tests.
+
+macro_rules! fixture {
+    ($module:ident, $path:literal) => {
+        mod $module {
+            include!($path);
+
+            pub fn run() {
+                main();
+            }
+        }
+    };
+}
+
+fixture!(child_should_inherit_fds, "child_should_inherit_fds/main.rs");
+fixture!(close_on_exec, "close_on_exec/main.rs");
+fixture!(dup2_existing_fd, "dup2_existing_fd/main.rs");
+fixture!(
+    dup_should_create_a_valid_fd,
+    "dup_should_create_a_valid_fd/main.rs"
+);
+fixture!(fcntl_dupfd, "fcntl_dupfd/main.rs");
+fixture!(fcntl_getfd_setfd, "fcntl_getfd_setfd/main.rs");
+fixture!(file_race_openwrite, "file_race_openwrite/main.rs");
+fixture!(file_write_race, "file_write_race/main.rs");
+fixture!(fstat, "fstat/main.rs");
+fixture!(hello_world_rs, "hello_world_rs/main.rs");
+fixture!(no_close_on_exec, "no_close_on_exec/main.rs");
+fixture!(open_null_ptr, "open_null_ptr/main.rs");
+fixture!(openat_lowest_fd, "openat_lowest_fd/main.rs");
+fixture!(openat_next_lowest_fd, "openat_next_lowest_fd/main.rs");
+fixture!(pipe_creates_valid_fds, "pipe_creates_valid_fds/main.rs");
+fixture!(print_race, "print_race/main.rs");
+fixture!(read_badfd, "read_badfd/main.rs");
+fixture!(sched_getaffinity, "sched_getaffinity/main.rs");
+fixture!(utime, "utime/main.rs");
+fixture!(utimes, "utimes/main.rs");
+
+fn main() {
+    let fixture = std::env::var("HERMIT_LIT_FIXTURE")
+        .expect("HERMIT_LIT_FIXTURE must name the lit fixture to run");
+
+    match fixture.as_str() {
+        "child_should_inherit_fds" => child_should_inherit_fds::run(),
+        "close_on_exec" => close_on_exec::run(),
+        "dup2_existing_fd" => dup2_existing_fd::run(),
+        "dup_should_create_a_valid_fd" => dup_should_create_a_valid_fd::run(),
+        "fcntl_dupfd" => fcntl_dupfd::run(),
+        "fcntl_getfd_setfd" => fcntl_getfd_setfd::run(),
+        "file_race_openwrite" => file_race_openwrite::run(),
+        "file_write_race" => file_write_race::run(),
+        "fstat" => fstat::run(),
+        "hello_world_rs" => hello_world_rs::run(),
+        "no_close_on_exec" => no_close_on_exec::run(),
+        "open_null_ptr" => open_null_ptr::run(),
+        "openat_lowest_fd" => openat_lowest_fd::run(),
+        "openat_next_lowest_fd" => openat_next_lowest_fd::run(),
+        "pipe_creates_valid_fds" => pipe_creates_valid_fds::run(),
+        "print_race" => print_race::run(),
+        "read_badfd" => read_badfd::run(),
+        "sched_getaffinity" => sched_getaffinity::run(),
+        "utime" => utime::run(),
+        "utimes" => utimes::run(),
+        other => panic!("unknown Detcore lit fixture: {other}"),
+    }
+}

--- a/detcore/tests/lit/fstat/main.rs
+++ b/detcore/tests/lit/fstat/main.rs
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-//! Checks that we can observe mod time changes.
+// Checks that we can observe mod time changes.
 
 // RUN: %me
 

--- a/detcore/tests/lit/no_close_on_exec/main.rs
+++ b/detcore/tests/lit/no_close_on_exec/main.rs
@@ -6,8 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-//! Tests that a file descriptor remains valid even after execve if O_CLOEXEC
-//! wasn't specified. See also the `close_on_exec` test.
+// Tests that a file descriptor remains valid even after execve if O_CLOEXEC
+// wasn't specified. See also the `close_on_exec` test.
 
 // RUN: %me
 
@@ -63,14 +63,19 @@ fn main() {
         ForkResult::Child => {
             fdread.close().expect("close failed");
 
-            let proc_self = "/proc/self/exe\0".as_ptr() as *const libc::c_char;
+            let proc_self = c"/proc/self/exe".as_ptr();
 
             // Execute thyself, passing in the pipe's file descriptor.
             unsafe {
+                let fixture_env = b"HERMIT_LIT_FIXTURE=no_close_on_exec\0";
+                let env = [
+                    fixture_env.as_ptr() as *const libc::c_char,
+                    ptr::null(),
+                ];
                 libc::execve(
                     proc_self,
                     &[proc_self, fdwrite_str.as_ptr() as *const _, ptr::null()] as *const *const _,
-                    &[ptr::null()] as *const *const _,
+                    env.as_ptr(),
                 )
             };
 

--- a/detcore/tests/testutils/src/lib.rs
+++ b/detcore/tests/testutils/src/lib.rs
@@ -230,24 +230,28 @@ macro_rules! make_det_test_variants {
 
     ( @one_variant "bottom", $fn:path ) => {
         #[test]
+        #[ignore = "requires PMU support for RCB counting"]
         fn bottom_detcore() {
             $fn(& $crate::BOTTOM_CFG);
         }
     };
     ( @one_variant "middle", $fn:path ) => {
         #[test]
+        #[ignore = "requires PMU support for RCB counting"]
         fn middle_detcore() {
             $fn(& $crate::MIDDLE_CFG);
         }
     };
     ( @one_variant "default", $fn:path ) => {
         #[test]
+        #[ignore = "requires PMU support for RCB counting"]
         fn default_detcore() {
             $fn(& ::core::default::Default::default());
         }
     };
     ( @one_variant "top", $fn:path ) => {
         #[test]
+        #[ignore = "requires PMU support for RCB counting"]
         fn top_detcore() {
             $fn(& $crate::TOP_CFG);
         }

--- a/detcore/tests/time/mod.rs
+++ b/detcore/tests/time/mod.rs
@@ -37,6 +37,7 @@ fn diff_nanos(t1: DateTime<Utc>, t2: DateTime<Utc>) -> i64 {
 }
 
 #[test]
+#[ignore = "requires PMU support for RCB counting"]
 fn tod_from_epoch() {
     let config = detcore::Config {
         virtualize_time: true,
@@ -56,6 +57,7 @@ fn tod_from_epoch() {
 }
 
 #[test]
+#[ignore = "requires PMU support for RCB counting"]
 fn tod_is_stable() {
     let config = detcore::Config {
         virtualize_time: true,
@@ -79,6 +81,7 @@ fn tod_is_stable() {
 }
 
 #[test]
+#[ignore = "requires PMU support for RCB counting"]
 fn tod_gettimeofday() {
     let mut tp: MaybeUninit<libc::timeval> = MaybeUninit::uninit();
     let config = detcore::Config {
@@ -142,6 +145,7 @@ mod tod_gettimeofday_delta {
 }
 
 #[test]
+#[ignore = "requires PMU support for RCB counting"]
 fn tod_time() {
     let mut tloc: i64 = 0;
     let config = detcore::Config {
@@ -165,6 +169,7 @@ fn tod_time() {
 /// Check that the initially observed time is still epoch.  This is a bit fragile, because
 /// it requires that the clock_gettime call be the VERY first instruction/syscall counted
 /// within the new process.
+#[ignore = "requires PMU support for RCB counting"]
 fn tod_clock_gettime() {
     let mut tp: MaybeUninit<libc::timespec> = MaybeUninit::uninit();
     let config = detcore::Config {
@@ -190,6 +195,7 @@ fn tod_clock_gettime() {
 }
 
 #[test]
+#[ignore = "requires PMU support for RCB counting"]
 fn tod_clock_getres() {
     let mut tp: MaybeUninit<libc::timespec> = MaybeUninit::uninit();
     let config = detcore::Config {
@@ -213,6 +219,7 @@ fn tod_clock_getres() {
 }
 
 #[test]
+#[ignore = "requires PMU support for RCB counting"]
 fn tod_clock_getres_2() {
     let multiplier = 1000.0;
     let config = detcore::Config {
@@ -243,6 +250,7 @@ fn tod_clock_getres_2() {
 }
 
 #[test]
+#[ignore = "requires PMU support for RCB counting"]
 fn rdtsc_deltas() {
     let config = detcore::Config {
         clock_multiplier: Some(12345.0),

--- a/hermit-cli/Cargo.toml
+++ b/hermit-cli/Cargo.toml
@@ -7,11 +7,22 @@ edition = "2024"
 repository = "https://github.com/facebookexperimental/hermit"
 license = "BSD-3-Clause"
 
+[[bin]]
+name = "detcore-lit-fixture"
+path = "../detcore/tests/lit/fixture.rs"
+test = false
+bench = false
+
+[[test]]
+name = "detcore_lit"
+path = "../detcore/tests/lit/cargo.rs"
+
 [dependencies]
 anyhow = "1.0.103"
 bincode = { version = "2", features = ["serde"] }
 clap = { version = "4.6.2", features = ["derive", "env", "string", "unicode", "wrap_help"] }
 colored = "2.1.0"
+close-err = "1.0.2"
 detcore = { version = "0.0.0", path = "../detcore" }
 diff = "0.1.13"
 dirs = "6.0"
@@ -30,9 +41,13 @@ reverie-ptrace = { version = "0.1.0", git = "https://github.com/facebookexperime
 serde = { version = "1.0.219", features = ["derive", "rc"] }
 serde_json = { version = "1.0.140", features = ["alloc", "float_roundtrip", "raw_value", "unbounded_depth"] }
 shell-words = "1.1.1"
+syscalls = "0.6.18"
 tempfile = "3.27.0"
 tokio = { version = "1.52.4", features = ["full", "test-util", "tracing"] }
 tracing = { version = "0.1.41", features = ["attributes", "valuable"] }
 tracing-appender = "0.2.5"
 tracing-subscriber = { version = "0.3.23", features = ["chrono", "env-filter", "json", "local-time", "parking_lot", "registry"] }
 uuid = { version = "1.24.0", features = ["rng-getrandom", "serde", "v4", "v5", "v6", "v7", "v8"] }
+
+[dev-dependencies]
+litcheck-filecheck = { version = "0.4.4", default-features = false }


### PR DESCRIPTION
## Summary
- add a Cargo-native runner for all 78 Detcore lit commands and a shared fixture dispatcher
- mark the 27 lit, 11 parallelism, and 12 timing cases that require PMU access as ignored by default
- run ignored PMU suites in the hardware CI job and document local execution
- isolate lit fixture state and preserve exec fixture selection across sanitized environments

The edited hermit-cli/Cargo.toml is generated; its additions mirror existing Buck-side fixture/dependency requirements and must remain synchronized by the exporter.

## Validation
- CARGO_TARGET_DIR=/home/newton/work/dev-hermit/targets/slot-batch-c cargo test --workspace
- cargo test -p hermit --test detcore_lit -- --ignored --test-threads=1 (27 passed)
- cargo test -p detcore --test tests_time -- --ignored --test-threads=1 (12 passed)
- cargo fmt --all -- --check
- cargo clippy --workspace --all-targets -- -D warnings

Three parallelism futex PMU variants pass. The eight memory variants trigger impractical per-instruction trace output; tracked in #74.

Related bugs found while porting: #73, #74.